### PR TITLE
CON-21 fix: Spring Security 관련 의존성 및 정책으로 인한 테스트 요청 거부 수정

### DIFF
--- a/microservices/composite-service/src/test/java/com/connectcrew/teamone/compositeservice/config/TestSecurityConfig.java
+++ b/microservices/composite-service/src/test/java/com/connectcrew/teamone/compositeservice/config/TestSecurityConfig.java
@@ -1,0 +1,27 @@
+package com.connectcrew.teamone.compositeservice.config;
+
+import com.connectcrew.teamone.compositeservice.auth.JwtAuthenticationManager;
+import com.connectcrew.teamone.compositeservice.auth.JwtSecurityContextRepository;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@TestConfiguration
+public class TestSecurityConfig {
+
+    @MockBean
+    JwtAuthenticationManager jwtAuthenticationManager;
+
+    @MockBean
+    JwtSecurityContextRepository jwtSecurityContextRepository;
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        return http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .authorizeExchange(spec -> spec.anyExchange().permitAll())
+                .build();
+    }
+}

--- a/microservices/composite-service/src/test/java/com/connectcrew/teamone/compositeservice/controller/AuthControllerTest.java
+++ b/microservices/composite-service/src/test/java/com/connectcrew/teamone/compositeservice/controller/AuthControllerTest.java
@@ -9,6 +9,7 @@ import com.connectcrew.teamone.api.user.auth.param.UserInputParam;
 import com.connectcrew.teamone.compositeservice.auth.Auth2User;
 import com.connectcrew.teamone.compositeservice.auth.TokenGenerator;
 import com.connectcrew.teamone.compositeservice.auth.TokenResolver;
+import com.connectcrew.teamone.compositeservice.config.TestSecurityConfig;
 import com.connectcrew.teamone.compositeservice.exception.UnauthorizedException;
 import com.connectcrew.teamone.compositeservice.param.LoginParam;
 import com.connectcrew.teamone.compositeservice.param.RegisterParam;
@@ -21,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
@@ -42,6 +44,7 @@ import static org.springframework.restdocs.webtestclient.WebTestClientRestDocume
 
 @WebFluxTest
 @ActiveProfiles("test")
+@Import(TestSecurityConfig.class)
 @ExtendWith(RestDocumentationExtension.class)
 class AuthControllerTest {
     @MockBean


### PR DESCRIPTION
# 작업 내용

- JWT 관련 Bean 객체들이 초기화 안되는 문제 해결
- Test용 SecurityWebFilterChain을 별도로 구성해 모든 요청을 허용