### PR TITLE
CON-45 fix: Apple Identity Token 분석이 안되는 문제 해결

### DIFF
--- a/microservices/composite-service/src/main/java/com/connectcrew/teamone/compositeservice/auth/Auth2TokenValidator.java
+++ b/microservices/composite-service/src/main/java/com/connectcrew/teamone/compositeservice/auth/Auth2TokenValidator.java
@@ -117,8 +117,10 @@ public class Auth2TokenValidator {
         }
     }
 
-    private Mono<PublicKey> getApplePublicKey(String kid) {
+    public Mono<PublicKey> getApplePublicKey(String kid) {
+        log.trace("getApplePublicKey kid={}", kid);
         return webClient.get()
+                .uri("https://appleid.apple.com/auth/keys")
                 .retrieve()
                 .bodyToMono(Map.class)
                 .flatMap(response -> {


### PR DESCRIPTION
- Apple Token을 분석할 때, Public Key 파싱이 안되는 문제를 해결했습니다.